### PR TITLE
Fix dimension error in shader sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const blink = `
 uniform vec2 resolution;
 uniform vec2 offset;
 uniform float time;
-uniform float src;
+uniform sampler2D src;
 
 void main() {
     vec2 uv = (gl_FragCoord.xy - offset) / resolution;


### PR DESCRIPTION
A shader sample in README seems to raise a dimension mismatch error. This PR fixes it.

<details>
<summary>Error log in Chrome Version 79.0.3945.130</summary>
<pre><code>THREE.WebGLProgram: shader error:  0 35715 false gl.getProgramInfoLog invalid shaders  THREE.WebGLShader: gl.getShaderInfoLog() fragment
ERROR: 0:119: 'texture2D' : no matching overloaded function found
ERROR: 0:119: '=' : dimension mismatch
ERROR: 0:119: 'assign' : cannot convert from 'highp float' to 'FragColor mediump 4-component vector of float'
1: #extension GL_OES_standard_derivatives : enable
2: #extension GL_EXT_frag_depth : enable
3: #extension GL_EXT_draw_buffers : require
4: #extension GL_EXT_shader_texture_lod : enable
5: precision highp float;
6: precision highp int;
7: #define HIGH_PRECISION
8: #define SHADER_NAME ShaderMaterial
9: #define GAMMA_FACTOR 2
10: #define TEXTURE_LOD_EXT
11: uniform mat4 viewMatrix;
12: uniform vec3 cameraPosition;
13: uniform bool isOrthographic;
14: #define TONE_MAPPING
15: #ifndef saturate
16: #define saturate(a) clamp( a, 0.0, 1.0 )
17: #endif
18: uniform float toneMappingExposure;
19: uniform float toneMappingWhitePoint;
20: vec3 LinearToneMapping( vec3 color ) {
21: 	return toneMappingExposure * color;
22: }
23: vec3 ReinhardToneMapping( vec3 color ) {
24: 	color *= toneMappingExposure;
25: 	return saturate( color / ( vec3( 1.0 ) + color ) );
26: }
27: #define Uncharted2Helper( x ) max( ( ( x * ( 0.15 * x + 0.10 * 0.50 ) + 0.20 * 0.02 ) / ( x * ( 0.15 * x + 0.50 ) + 0.20 * 0.30 ) ) - 0.02 / 0.30, vec3( 0.0 ) )
28: vec3 Uncharted2ToneMapping( vec3 color ) {
29: 	color *= toneMappingExposure;
30: 	return saturate( Uncharted2Helper( color ) / Uncharted2Helper( vec3( toneMappingWhitePoint ) ) );
31: }
32: vec3 OptimizedCineonToneMapping( vec3 color ) {
33: 	color *= toneMappingExposure;
34: 	color = max( vec3( 0.0 ), color - 0.004 );
35: 	return pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );
36: }
37: vec3 ACESFilmicToneMapping( vec3 color ) {
38: 	color *= toneMappingExposure;
39: 	return saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );
40: }
41: vec3 toneMapping( vec3 color ) { return LinearToneMapping( color ); }
42: 
43: vec4 LinearToLinear( in vec4 value ) {
44: 	return value;
45: }
46: vec4 GammaToLinear( in vec4 value, in float gammaFactor ) {
47: 	return vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );
48: }
49: vec4 LinearToGamma( in vec4 value, in float gammaFactor ) {
50: 	return vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );
51: }
52: vec4 sRGBToLinear( in vec4 value ) {
53: 	return vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );
54: }
55: vec4 LinearTosRGB( in vec4 value ) {
56: 	return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );
57: }
58: vec4 RGBEToLinear( in vec4 value ) {
59: 	return vec4( value.rgb * exp2( value.a * 255.0 - 128.0 ), 1.0 );
60: }
61: vec4 LinearToRGBE( in vec4 value ) {
62: 	float maxComponent = max( max( value.r, value.g ), value.b );
63: 	float fExp = clamp( ceil( log2( maxComponent ) ), -128.0, 127.0 );
64: 	return vec4( value.rgb / exp2( fExp ), ( fExp + 128.0 ) / 255.0 );
65: }
66: vec4 RGBMToLinear( in vec4 value, in float maxRange ) {
67: 	return vec4( value.rgb * value.a * maxRange, 1.0 );
68: }
69: vec4 LinearToRGBM( in vec4 value, in float maxRange ) {
70: 	float maxRGB = max( value.r, max( value.g, value.b ) );
71: 	float M = clamp( maxRGB / maxRange, 0.0, 1.0 );
72: 	M = ceil( M * 255.0 ) / 255.0;
73: 	return vec4( value.rgb / ( M * maxRange ), M );
74: }
75: vec4 RGBDToLinear( in vec4 value, in float maxRange ) {
76: 	return vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );
77: }
78: vec4 LinearToRGBD( in vec4 value, in float maxRange ) {
79: 	float maxRGB = max( value.r, max( value.g, value.b ) );
80: 	float D = max( maxRange / maxRGB, 1.0 );
81: 	D = min( floor( D ) / 255.0, 1.0 );
82: 	return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
83: }
84: const mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );
85: vec4 LinearToLogLuv( in vec4 value )  {
86: 	vec3 Xp_Y_XYZp = cLogLuvM * value.rgb;
87: 	Xp_Y_XYZp = max( Xp_Y_XYZp, vec3( 1e-6, 1e-6, 1e-6 ) );
88: 	vec4 vResult;
89: 	vResult.xy = Xp_Y_XYZp.xy / Xp_Y_XYZp.z;
90: 	float Le = 2.0 * log2(Xp_Y_XYZp.y) + 127.0;
91: 	vResult.w = fract( Le );
92: 	vResult.z = ( Le - ( floor( vResult.w * 255.0 ) ) / 255.0 ) / 255.0;
93: 	return vResult;
94: }
95: const mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );
96: vec4 LogLuvToLinear( in vec4 value ) {
97: 	float Le = value.z * 255.0 + value.w;
98: 	vec3 Xp_Y_XYZp;
99: 	Xp_Y_XYZp.y = exp2( ( Le - 127.0 ) / 2.0 );
100: 	Xp_Y_XYZp.z = Xp_Y_XYZp.y / value.y;
101: 	Xp_Y_XYZp.x = value.x * Xp_Y_XYZp.z;
102: 	vec3 vRGB = cLogLuvInverseM * Xp_Y_XYZp.rgb;
103: 	return vec4( max( vRGB, 0.0 ), 1.0 );
104: }
105: vec4 mapTexelToLinear( vec4 value ) { return LinearToLinear( value ); }
106: vec4 matcapTexelToLinear( vec4 value ) { return LinearToLinear( value ); }
107: vec4 envMapTexelToLinear( vec4 value ) { return LinearToLinear( value ); }
108: vec4 emissiveMapTexelToLinear( vec4 value ) { return LinearToLinear( value ); }
109: vec4 linearToOutputTexel( vec4 value ) { return LinearToLinear( value ); }
110: 
111: 
112: uniform vec2 resolution;
113: uniform vec2 offset;
114: uniform float time;
115: uniform float src;
116: 
117: void main() {
118:     vec2 uv = (gl_FragCoord.xy - offset) / resolution;
119:     gl_FragColor = texture2D(src, uv) * step(.5, fract(time));
120: }
121: </code></pre>
</details>