### PR TITLE
fix: recreate CanvasTexture in rerenderTextElement

### DIFF
--- a/packages/react-vfx/src/vfx-player.ts
+++ b/packages/react-vfx/src/vfx-player.ts
@@ -119,17 +119,20 @@ export default class VFXPlayer {
         try {
             e.element.style.setProperty("opacity", "1"); // TODO: Restore original opacity
 
-            const texture: THREE.CanvasTexture = e.uniforms["src"].value;
-            const canvas = texture.image;
+            const oldTexture: THREE.CanvasTexture = e.uniforms["src"].value;
+            const canvas = oldTexture.image;
+
+            const texture = new THREE.CanvasTexture(canvas);
 
             await dom2canvas(e.element, canvas);
             if (canvas.width === 0 || canvas.width === 0) {
                 throw "omg";
             }
 
-            e.element.style.setProperty("opacity", "0");
+            e.uniforms["src"].value = texture;
+            oldTexture.dispose();
 
-            texture.needsUpdate = true;
+            e.element.style.setProperty("opacity", "0");
         } catch (e) {
             console.error(e);
         }


### PR DESCRIPTION
This PR fixes `VFXSpan` etc not updating the contents correctly.

Three.js doesn't support updating texture data if the texture size has been changed.
This change was introduced in r135:
https://github.com/mrdoob/three.js/issues/23164#issuecomment-1007226703

So we have to create textures every time we need to update the contents of `VFXSpan` etc.


## Changes
- Recreate CanvasTexture every time the contents of the target node is updated