### PR TITLE
docs: fix highlight broken on prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7258,6 +7258,7 @@
         "@react-three/fiber": "^8.16.8",
         "@react-three/postprocessing": "^2.16.2",
         "dedent": "^1.5.3",
+        "highlight.js": "11.9.0",
         "is-mobile": "^4.0.0",
         "lodash.debounce": "^4.0.8",
         "postprocessing": "^6.35.5",
@@ -7372,6 +7373,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/docs/node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "packages/docs/node_modules/minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7258,7 +7258,6 @@
         "@react-three/fiber": "^8.16.8",
         "@react-three/postprocessing": "^2.16.2",
         "dedent": "^1.5.3",
-        "highlight.js": "11.9.0",
         "is-mobile": "^4.0.0",
         "lodash.debounce": "^4.0.8",
         "postprocessing": "^6.35.5",
@@ -7373,14 +7372,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/docs/node_modules/highlight.js": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "packages/docs/node_modules/minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1519,6 +1519,11 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.4",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.4.tgz",
+      "integrity": "sha512-rlAnzkW2sZOjbqZ743IHUhFcvzaGbqijwOu8QZnZCjfQzBqFE3s4lOTJEsxikImav9uzz/42I+O7YUs1mWgMlg=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -2108,6 +2113,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5646,6 +5659,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prism-react-renderer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.1.tgz",
+      "integrity": "sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
@@ -7261,6 +7286,7 @@
         "is-mobile": "^4.0.0",
         "lodash.debounce": "^4.0.8",
         "postprocessing": "^6.35.5",
+        "prism-react-renderer": "^2.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-lazyload": "^3.2.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.3.1",
     "react-lazyload": "^3.2.1",
     "react-syntax-highlighter": "^15.5.0",
+    "highlight.js": "11.9.0",
     "react-vfx": "*",
     "three": "^0.165.0",
     "vh-check": "^2.0.5"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,7 +20,6 @@
     "react-dom": "^18.3.1",
     "react-lazyload": "^3.2.1",
     "react-syntax-highlighter": "^15.5.0",
-    "highlight.js": "11.9.0",
     "react-vfx": "*",
     "three": "^0.165.0",
     "vh-check": "^2.0.5"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,6 +16,7 @@
     "is-mobile": "^4.0.0",
     "lodash.debounce": "^4.0.8",
     "postprocessing": "^6.35.5",
+    "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-lazyload": "^3.2.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,7 +20,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-lazyload": "^3.2.1",
-    "react-syntax-highlighter": "^15.5.0",
     "react-vfx": "*",
     "three": "^0.165.0",
     "vh-check": "^2.0.5"
@@ -34,7 +33,6 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-lazyload": "^3.2.3",
-    "@types/react-syntax-highlighter": "^15.5.13",
     "@types/three": "^0.165.0",
     "@vitejs/plugin-react": "^4.3.0",
     "rimraf": "^5.0.7",

--- a/packages/docs/src/dom/Code.tsx
+++ b/packages/docs/src/dom/Code.tsx
@@ -9,12 +9,15 @@ const preStyle = {
     lineHeight: 1.5,
     textAlign: "left",
     overflowX: "auto",
+    backgroundColor: "rgba(0,0,0,0.8)",
 };
 
 const inlineStyle = {
     fontSize: "0.8em",
     margin: "4px",
     padding: "4px 8px",
+    color: "#EEEEEE",
+    backgroundColor: "rgba(0,0,0,0.8)",
 };
 
 export const Code = ({ children }: any) => (
@@ -36,17 +39,5 @@ export const Code = ({ children }: any) => (
 );
 
 export const InlineCode = ({ children }: any) => (
-    <Highlight language="jsx" theme={themes.oneDark} code={children}>
-        {({ style, tokens, getLineProps, getTokenProps }) => (
-            <code style={{ ...style, ...inlineStyle }}>
-                {tokens.map((line, i) => (
-                    <span key={i} {...getLineProps({ line })}>
-                        {line.map((token, key) => (
-                            <span key={key} {...getTokenProps({ token })} />
-                        ))}
-                    </span>
-                ))}
-            </code>
-        )}
-    </Highlight>
+    <code style={inlineStyle}>{children}</code>
 );

--- a/packages/docs/src/dom/Code.tsx
+++ b/packages/docs/src/dom/Code.tsx
@@ -1,20 +1,10 @@
 import React from "react";
 
-// import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
-// import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
-// import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
+import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-// SyntaxHighlighter.registerLanguage("jsx", jsx);
-
-import hljs from "highlight.js/lib/core";
-import "highlight.js/styles/tokyo-night-dark.min.css";
-
-import javascript from "highlight.js/lib/languages/javascript";
-hljs.registerLanguage("javascript", javascript);
-import glsl from "highlight.js/lib/languages/glsl";
-hljs.registerLanguage("glsl", glsl);
-// import jsx from "highlight.js/lib/languages/jsx";
-// hljs.registerLanguage("jsx", jsx);
+SyntaxHighlighter.registerLanguage("jsx", jsx);
 
 const Frag = ({ children }: any) => <>{children}</>;
 
@@ -22,28 +12,22 @@ const style = {
     fontSize: "20px",
     width: "960px",
     maxWidth: "calc(100% - 40px)",
-    margin: "0 auto",
-    textAlign: "left",
+    margin: "0 auto"
 };
 
-export const Code = ({ children }: any) => {
-    const c = hljs.highlight("javascript", children);
-
-    return (
-        <pre style={style}>
-            <div dangerouslySetInnerHTML={{ __html: c.value }} />
-        </pre>
-    );
-};
+export const Code = ({ children }: any) => (
+    <SyntaxHighlighter language="jsx" style={darcula} customStyle={style}>
+        {children}
+    </SyntaxHighlighter>
+);
 
 export const InlineCode = ({ children }: any) => (
-    <code>{children}</code>
-    // <SyntaxHighlighter
-    //     language="jsx"
-    //     style={darcula}
-    //     customStyle={style}
-    //     PreTag={Frag}
-    // >
-    //     {children}
-    // </SyntaxHighlighter>
+    <SyntaxHighlighter
+        language="jsx"
+        style={darcula}
+        customStyle={style}
+        PreTag={Frag}
+    >
+        {children}
+    </SyntaxHighlighter>
 );

--- a/packages/docs/src/dom/Code.tsx
+++ b/packages/docs/src/dom/Code.tsx
@@ -1,10 +1,20 @@
 import React from "react";
 
-import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
-import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
-import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
+// import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
+// import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
+// import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-SyntaxHighlighter.registerLanguage("jsx", jsx);
+// SyntaxHighlighter.registerLanguage("jsx", jsx);
+
+import hljs from "highlight.js/lib/core";
+import "highlight.js/styles/tokyo-night-dark.min.css";
+
+import javascript from "highlight.js/lib/languages/javascript";
+hljs.registerLanguage("javascript", javascript);
+import glsl from "highlight.js/lib/languages/glsl";
+hljs.registerLanguage("glsl", glsl);
+// import jsx from "highlight.js/lib/languages/jsx";
+// hljs.registerLanguage("jsx", jsx);
 
 const Frag = ({ children }: any) => <>{children}</>;
 
@@ -12,22 +22,28 @@ const style = {
     fontSize: "20px",
     width: "960px",
     maxWidth: "calc(100% - 40px)",
-    margin: "0 auto"
+    margin: "0 auto",
+    textAlign: "left",
 };
 
-export const Code = ({ children }: any) => (
-    <SyntaxHighlighter language="jsx" style={darcula} customStyle={style}>
-        {children}
-    </SyntaxHighlighter>
-);
+export const Code = ({ children }: any) => {
+    const c = hljs.highlight("javascript", children);
+
+    return (
+        <pre style={style}>
+            <div dangerouslySetInnerHTML={{ __html: c.value }} />
+        </pre>
+    );
+};
 
 export const InlineCode = ({ children }: any) => (
-    <SyntaxHighlighter
-        language="jsx"
-        style={darcula}
-        customStyle={style}
-        PreTag={Frag}
-    >
-        {children}
-    </SyntaxHighlighter>
+    <code>{children}</code>
+    // <SyntaxHighlighter
+    //     language="jsx"
+    //     style={darcula}
+    //     customStyle={style}
+    //     PreTag={Frag}
+    // >
+    //     {children}
+    // </SyntaxHighlighter>
 );

--- a/packages/docs/src/dom/Code.tsx
+++ b/packages/docs/src/dom/Code.tsx
@@ -10,7 +10,7 @@ const preStyle = {
     textAlign: "left",
     overflowX: "auto",
     backgroundColor: "rgba(0,0,0,0.8)",
-};
+} as const;
 
 const inlineStyle = {
     fontSize: "0.8em",
@@ -18,7 +18,7 @@ const inlineStyle = {
     padding: "4px 8px",
     color: "#EEEEEE",
     backgroundColor: "rgba(0,0,0,0.8)",
-};
+} as const;
 
 export const Code = ({ children }: any) => (
     <div>

--- a/packages/docs/src/dom/Code.tsx
+++ b/packages/docs/src/dom/Code.tsx
@@ -1,33 +1,52 @@
-import React from "react";
+import { Highlight, themes } from "prism-react-renderer";
 
-import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
-import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
-import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
-
-SyntaxHighlighter.registerLanguage("jsx", jsx);
-
-const Frag = ({ children }: any) => <>{children}</>;
-
-const style = {
-    fontSize: "20px",
+const preStyle = {
+    fontSize: "0.6em",
     width: "960px",
     maxWidth: "calc(100% - 40px)",
-    margin: "0 auto"
+    margin: "0 auto",
+    padding: "16px",
+    lineHeight: 1.5,
+    textAlign: "left",
+    overflowX: "auto",
+};
+
+const inlineStyle = {
+    fontSize: "0.8em",
+    margin: "4px",
+    padding: "4px 8px",
 };
 
 export const Code = ({ children }: any) => (
-    <SyntaxHighlighter language="jsx" style={darcula} customStyle={style}>
-        {children}
-    </SyntaxHighlighter>
+    <div>
+        <Highlight language="jsx" theme={themes.oneDark} code={children}>
+            {({ style, tokens, getLineProps, getTokenProps }) => (
+                <pre style={{ ...style, ...preStyle }}>
+                    {tokens.map((line, i) => (
+                        <div key={i} {...getLineProps({ line })}>
+                            {line.map((token, key) => (
+                                <span key={key} {...getTokenProps({ token })} />
+                            ))}
+                        </div>
+                    ))}
+                </pre>
+            )}
+        </Highlight>
+    </div>
 );
 
 export const InlineCode = ({ children }: any) => (
-    <SyntaxHighlighter
-        language="jsx"
-        style={darcula}
-        customStyle={style}
-        PreTag={Frag}
-    >
-        {children}
-    </SyntaxHighlighter>
+    <Highlight language="jsx" theme={themes.oneDark} code={children}>
+        {({ style, tokens, getLineProps, getTokenProps }) => (
+            <code style={{ ...style, ...inlineStyle }}>
+                {tokens.map((line, i) => (
+                    <span key={i} {...getLineProps({ line })}>
+                        {line.map((token, key) => (
+                            <span key={key} {...getTokenProps({ token })} />
+                        ))}
+                    </span>
+                ))}
+            </code>
+        )}
+    </Highlight>
 );


### PR DESCRIPTION
`react-syntax-highlight` has an issue that it fails to render code correctly on prod.

<img width="1141" alt="image" src="https://github.com/fand/react-vfx/assets/1403842/90c7cb48-6871-40d9-8d12-7ad879841469">

ref. https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/513


This PR solves this by using `prism-react-renderer` instead.