### PR TITLE
fix: init elements only if they are loaded

### DIFF
--- a/packages/react-vfx/src/element.tsx
+++ b/packages/react-vfx/src/element.tsx
@@ -31,12 +31,12 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
 
         // Create scene
         useEffect(() => {
-            const element = elementRef.current;
-            if (element === undefined) {
+            if (!player || !elementRef.current) {
                 return;
             }
+            const element = elementRef.current;
 
-            player?.addElement(element, {
+            player.addElement(element, {
                 shader,
                 release,
                 uniforms,
@@ -55,8 +55,8 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
             });
 
             return () => {
-                player?.removeElement(element);
                 mo.disconnect();
+                player.removeElement(element);
             };
         }, [elementRef, player, shader, release, uniforms, overflow]);
 

--- a/packages/react-vfx/src/element.tsx
+++ b/packages/react-vfx/src/element.tsx
@@ -1,33 +1,37 @@
 import * as React from "react";
 import { useEffect, useRef, useContext } from "react";
 import { VFXContext } from "./context";
-import { VFXProps } from "./types";
+import type { VFXProps } from "./types";
+import type VFXPlayer from "./vfx-player";
 
 type VFXElementProps<T extends keyof JSX.IntrinsicElements> =
     JSX.IntrinsicElements[T] & VFXProps;
+
+type VFXElementInnerProps<T extends keyof JSX.IntrinsicElements> =
+    VFXElementProps<T> & {
+        player: VFXPlayer;
+        refCallback: (e: HTMLElement) => void;
+    };
 
 function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
     type: T,
 ): React.ForwardRefExoticComponent<
     React.PropsWithoutRef<VFXElementProps<T>> & React.RefAttributes<HTMLElement>
 > {
-    return React.forwardRef(function VFXElement(
-        props: VFXElementProps<T>,
-        parentRef: React.ForwardedRef<HTMLElement>,
-    ) {
-        const player = useContext(VFXContext);
-
+    const VFXElementInner: React.FC<VFXElementInnerProps<T>> = ({
+        player,
+        refCallback,
+        shader,
+        release,
+        uniforms,
+        overflow,
+        ...rawProps
+    }) => {
         const elementRef = useRef<HTMLElement | undefined>();
         const ref = (e: HTMLElement): void => {
             elementRef.current = e;
-            if (parentRef instanceof Function) {
-                parentRef(e);
-            } else if (parentRef) {
-                parentRef.current = e;
-            }
+            refCallback(e);
         };
-
-        const { shader, release, uniforms, overflow, ...rawProps } = props;
 
         // Create scene
         useEffect(() => {
@@ -36,7 +40,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
                 return;
             }
 
-            player?.addElement(element, {
+            player.addElement(element, {
                 shader,
                 release,
                 uniforms,
@@ -45,7 +49,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
 
             const mo = new MutationObserver(() => {
                 if (elementRef.current) {
-                    player?.updateTextElement(elementRef.current);
+                    player.updateTextElement(elementRef.current);
                 }
             });
             mo.observe(element, {
@@ -55,12 +59,32 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
             });
 
             return () => {
-                player?.removeElement(element);
+                player.removeElement(element);
                 mo.disconnect();
             };
         }, [elementRef, player, shader, release, uniforms, overflow]);
 
         return React.createElement(type, { ...rawProps, ref });
+    };
+
+    return React.forwardRef(function VFXElement(
+        props: VFXElementProps<T>,
+        parentRef: React.ForwardedRef<HTMLElement>,
+    ) {
+        const player = useContext(VFXContext);
+        if (!player) {
+            return null;
+        }
+
+        const ref = (e: HTMLElement): void => {
+            if (parentRef instanceof Function) {
+                parentRef(e);
+            } else if (parentRef) {
+                parentRef.current = e;
+            }
+        };
+
+        return <VFXElementInner refCallback={ref} player={player} {...props} />;
     });
 }
 

--- a/packages/react-vfx/src/element.tsx
+++ b/packages/react-vfx/src/element.tsx
@@ -1,37 +1,33 @@
 import * as React from "react";
 import { useEffect, useRef, useContext } from "react";
 import { VFXContext } from "./context";
-import type { VFXProps } from "./types";
-import type VFXPlayer from "./vfx-player";
+import { VFXProps } from "./types";
 
 type VFXElementProps<T extends keyof JSX.IntrinsicElements> =
     JSX.IntrinsicElements[T] & VFXProps;
-
-type VFXElementInnerProps<T extends keyof JSX.IntrinsicElements> =
-    VFXElementProps<T> & {
-        player: VFXPlayer;
-        refCallback: (e: HTMLElement) => void;
-    };
 
 function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
     type: T,
 ): React.ForwardRefExoticComponent<
     React.PropsWithoutRef<VFXElementProps<T>> & React.RefAttributes<HTMLElement>
 > {
-    const VFXElementInner: React.FC<VFXElementInnerProps<T>> = ({
-        player,
-        refCallback,
-        shader,
-        release,
-        uniforms,
-        overflow,
-        ...rawProps
-    }) => {
+    return React.forwardRef(function VFXElement(
+        props: VFXElementProps<T>,
+        parentRef: React.ForwardedRef<HTMLElement>,
+    ) {
+        const player = useContext(VFXContext);
+
         const elementRef = useRef<HTMLElement | undefined>();
         const ref = (e: HTMLElement): void => {
             elementRef.current = e;
-            refCallback(e);
+            if (parentRef instanceof Function) {
+                parentRef(e);
+            } else if (parentRef) {
+                parentRef.current = e;
+            }
         };
+
+        const { shader, release, uniforms, overflow, ...rawProps } = props;
 
         // Create scene
         useEffect(() => {
@@ -40,7 +36,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
                 return;
             }
 
-            player.addElement(element, {
+            player?.addElement(element, {
                 shader,
                 release,
                 uniforms,
@@ -49,7 +45,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
 
             const mo = new MutationObserver(() => {
                 if (elementRef.current) {
-                    player.updateTextElement(elementRef.current);
+                    player?.updateTextElement(elementRef.current);
                 }
             });
             mo.observe(element, {
@@ -59,32 +55,12 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
             });
 
             return () => {
-                player.removeElement(element);
+                player?.removeElement(element);
                 mo.disconnect();
             };
         }, [elementRef, player, shader, release, uniforms, overflow]);
 
         return React.createElement(type, { ...rawProps, ref });
-    };
-
-    return React.forwardRef(function VFXElement(
-        props: VFXElementProps<T>,
-        parentRef: React.ForwardedRef<HTMLElement>,
-    ) {
-        const player = useContext(VFXContext);
-        if (!player) {
-            return null;
-        }
-
-        const ref = (e: HTMLElement): void => {
-            if (parentRef instanceof Function) {
-                parentRef(e);
-            } else if (parentRef) {
-                parentRef.current = e;
-            }
-        };
-
-        return <VFXElementInner refCallback={ref} player={player} {...props} />;
     });
 }
 

--- a/packages/react-vfx/src/image.tsx
+++ b/packages/react-vfx/src/image.tsx
@@ -13,11 +13,12 @@ export const VFXImg: React.FC<VFXImgProps> = (props) => {
 
     // Create scene
     const init = useCallback(() => {
-        if (ref.current === null) {
+        if (!player || !ref.current) {
             return;
         }
+        const element = ref.current;
 
-        player?.addElement(ref.current, {
+        player.addElement(element, {
             shader,
             release,
             uniforms,
@@ -25,11 +26,7 @@ export const VFXImg: React.FC<VFXImgProps> = (props) => {
         });
 
         return () => {
-            if (ref.current === null) {
-                return;
-            }
-
-            player?.removeElement(ref.current);
+            player.removeElement(element);
         };
     }, [player, shader, release, uniforms, overflow]);
 

--- a/packages/react-vfx/src/image.tsx
+++ b/packages/react-vfx/src/image.tsx
@@ -1,19 +1,20 @@
 import * as React from "react";
-import { useRef, useContext, useCallback } from "react";
+import { useRef, useContext, useEffect, useState } from "react";
 import { VFXContext } from "./context";
 import { VFXProps } from "./types";
 
 export type VFXImgProps = JSX.IntrinsicElements["img"] & VFXProps;
 
 export const VFXImg: React.FC<VFXImgProps> = (props) => {
-    const player = useContext(VFXContext);
-    const ref = useRef<HTMLImageElement>(null);
-
     const { shader, release, uniforms, overflow, ...rawProps } = props;
 
+    const player = useContext(VFXContext);
+    const ref = useRef<HTMLImageElement>(null);
+    const [isLoaded, setIsLoaded] = useState(false);
+
     // Create scene
-    const init = useCallback(() => {
-        if (!player || !ref.current) {
+    useEffect(() => {
+        if (!player || !ref.current || !isLoaded) {
             return;
         }
         const element = ref.current;
@@ -28,7 +29,7 @@ export const VFXImg: React.FC<VFXImgProps> = (props) => {
         return () => {
             player.removeElement(element);
         };
-    }, [player, shader, release, uniforms, overflow]);
+    }, [player, shader, release, uniforms, overflow, isLoaded]);
 
-    return <img ref={ref} {...rawProps} onLoad={init} />;
+    return <img ref={ref} {...rawProps} onLoad={() => setIsLoaded(true)} />;
 };

--- a/packages/react-vfx/src/video.tsx
+++ b/packages/react-vfx/src/video.tsx
@@ -13,11 +13,12 @@ export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
 
     // Create scene
     const onLoadedData = useCallback(() => {
-        if (ref.current === null) {
+        if (!player || !ref.current) {
             return;
         }
+        const element = ref.current;
 
-        player?.addElement(ref.current, {
+        player.addElement(element, {
             shader,
             release,
             uniforms,
@@ -25,11 +26,7 @@ export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
         });
 
         return () => {
-            if (ref.current === null) {
-                return;
-            }
-
-            player?.removeElement(ref.current);
+            player.removeElement(element);
         };
     }, [player, shader, release, uniforms, overflow]);
 

--- a/packages/react-vfx/src/video.tsx
+++ b/packages/react-vfx/src/video.tsx
@@ -1,19 +1,20 @@
 import * as React from "react";
-import { useRef, useContext, useCallback } from "react";
+import { useRef, useContext, useState, useEffect } from "react";
 import { VFXContext } from "./context";
 import { VFXProps } from "./types";
 
 export type VFXVideoProps = JSX.IntrinsicElements["video"] & VFXProps;
 
 export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
-    const player = useContext(VFXContext);
-    const ref = useRef<HTMLVideoElement>(null);
-
     const { shader, release, uniforms, overflow, ...rawProps } = props;
 
+    const player = useContext(VFXContext);
+    const ref = useRef<HTMLVideoElement>(null);
+    const [isLoaded, setIsLoaded] = useState(false);
+
     // Create scene
-    const onLoadedData = useCallback(() => {
-        if (!player || !ref.current) {
+    useEffect(() => {
+        if (!player || !ref.current || !isLoaded) {
             return;
         }
         const element = ref.current;
@@ -28,7 +29,9 @@ export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
         return () => {
             player.removeElement(element);
         };
-    }, [player, shader, release, uniforms, overflow]);
+    }, [player, shader, release, uniforms, overflow, isLoaded]);
 
-    return <video ref={ref} {...rawProps} onLoadedData={onLoadedData} />;
+    return (
+        <video ref={ref} {...rawProps} onLoadedData={() => setIsLoaded(true)} />
+    );
 };


### PR DESCRIPTION
REACT-VFX fails to add elements if the element is loaded before VFXPlayer is initialized.
This PR fixes this issue by checking if element and player are both ready before initialization.

