### PR TITLE
fix: improve image / video loading algorithm

### DIFF
--- a/packages/vfx-js/src/vfx.ts
+++ b/packages/vfx-js/src/vfx.ts
@@ -62,19 +62,27 @@ export class VFX {
         if (element.complete) {
             this.#player.addElement(element, opts);
         } else {
-            element.addEventListener("load", () => {
-                this.#player.addElement(element, opts);
-            });
+            element.addEventListener(
+                "load",
+                () => {
+                    this.#player.addElement(element, opts);
+                },
+                { once: true },
+            );
         }
     }
 
     #addVideo(element: HTMLVideoElement, opts: VFXProps): void {
-        if (element.readyState >= 4) {
+        if (element.readyState >= 3) {
             this.#player.addElement(element, opts);
         } else {
-            element.addEventListener("load", () => {
-                this.#player.addElement(element, opts);
-            });
+            element.addEventListener(
+                "canplay",
+                () => {
+                    this.#player.addElement(element, opts);
+                },
+                { once: true },
+            );
         }
     }
 


### PR DESCRIPTION
Currently videos on the docs page are not being loaded to WebGL context on mobile devices.
This PR improves the loading logic of image / video.