### PR TITLE
fix: package compatibility for ESM and CJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7609,6 +7609,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-tsconfig": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/resolve-tsconfig/-/resolve-tsconfig-1.3.0.tgz",
+      "integrity": "sha512-Ba5mo3soshb2CnIcNFz75F/80H/2eMVxrlmdgoSDNH7Lr6UAoT3BvxNtc7+VXqKSBlC0SJk2qSXOTcy0/p7cFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/skarab42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -8725,6 +8741,24 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsconfig-to-dual-package": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-to-dual-package/-/tsconfig-to-dual-package-1.2.0.tgz",
+      "integrity": "sha512-UtMinqTLfWr9fX6KidLsEcCJoA/jSLPIS00ohpQybMSxA3LlJCRf2DsGPw4AJJ8AP4FOHfbQJFJ5XgLoL7RoLw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-tsconfig": "^1.3.0"
+      },
+      "bin": {
+        "tsconfig-to-dual-package": "bin/cmd.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0 || >=16.17.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/tty-table": {
@@ -10101,6 +10135,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.1",
         "rimraf": "^5.0.7",
+        "tsconfig-to-dual-package": "^1.2.0",
         "typedoc": "^0.26.2",
         "typedoc-plugin-missing-exports": "^3.0.0",
         "typescript": "^5.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10044,6 +10044,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.1",
         "rimraf": "^5.0.7",
+        "tsconfig-to-dual-package": "^1.2.0",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,22 +15,22 @@
     "prepare-release": "changeset && turbo run build lint test && changeset version",
     "release": "changeset publish"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fand/react-vfx.git"
+  "dependencies": {
+    "@changesets/cli": "^2.27.5"
   },
-  "keywords": [],
-  "author": "AMAGI <mail@amagi.dev> (https://amagi.dev/)",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/fand/react-vfx/issues"
-  },
-  "homepage": "https://github.com/fand/react-vfx#readme",
   "devDependencies": {
     "husky": "^9.0.11",
     "turbo": "^2.0.3"
   },
-  "dependencies": {
-    "@changesets/cli": "^2.27.5"
-  }
+  "author": "AMAGI <mail@amagi.dev> (https://amagi.dev/)",
+  "homepage": "https://github.com/fand/react-vfx#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fand/react-vfx.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fand/react-vfx/issues"
+  },
+  "keywords": [],
+  "license": "MIT"
 }

--- a/packages/react-vfx/.prettierrc.mjs
+++ b/packages/react-vfx/.prettierrc.mjs
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
     tabWidth: 4,
 };

--- a/packages/react-vfx/package.json
+++ b/packages/react-vfx/package.json
@@ -2,18 +2,43 @@
   "name": "react-vfx",
   "description": "WebGL effects for React elements",
   "version": "0.7.0",
-  "author": "Takayosi Amagi <fand.gmork@gmail.com> (https://amagi.dev/)",
-  "bugs": {
-    "url": "https://github.com/fand/react-vfx/issues"
-  },
-  "dependencies": {
-    "@vfx-js/core": "0.2.0"
-  },
   "files": [
     "package.json",
     "README.md",
     "lib/"
   ],
+  "type": "module",
+  "main": "./lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "exports": {
+    "require": {
+      "types": "./lib/cjs/index.d.ts",
+      "default": "./lib/cjs/index.js"
+    },
+    "import": {
+      "types": "./lib/esm/index.d.ts",
+      "default": "./lib/esm/index.js"
+    }
+  },
+  "scripts": {
+    "build": "run-s clean build:cjs build:esm build:dual",
+    "build:cjs": "tsc -d",
+    "build:esm": "tsc -d -p tsconfig.esm.json",
+    "build:dual": "tsconfig-to-dual-package",
+    "clean": "rimraf lib",
+    "dev": "run-p watch:cjs watch:esm",
+    "watch:cjs": "tsc -d -w",
+    "watch:esm": "tsc -d -w -p tsconfig.esm.json",
+    "lint": "eslint src/**/*.ts src/**/*.tsx",
+    "lint-staged": "lint-staged"
+  },
+  "peerDependencies": {
+    "react": ">= 16.12.0",
+    "react-dom": ">= 16.12.0"
+  },
+  "dependencies": {
+    "@vfx-js/core": "0.2.0"
+  },
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
@@ -32,50 +57,25 @@
     "tsconfig-to-dual-package": "^1.2.0",
     "typescript": "^5.4.5"
   },
-  "homepage": "https://amagi.dev/react-vfx",
-  "keywords": [
-    "glsl",
-    "react",
-    "threejs",
-    "webgl"
-  ],
-  "license": "MIT",
   "lint-staged": {
     "src/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
     ]
   },
-  "type": "module",
-  "main": "./lib/esm/index.js",
-  "exports": {
-    "require": {
-      "types": "./lib/cjs/index.d.ts",
-      "default": "./lib/cjs/index.js"
-    },
-    "import": {
-      "types": "./lib/esm/index.d.ts",
-      "default": "./lib/esm/index.js"
-    }
-  },
-  "peerDependencies": {
-    "react": ">= 16.12.0",
-    "react-dom": ">= 16.12.0"
-  },
+  "author": "Takayosi Amagi <fand.gmork@gmail.com> (https://amagi.dev/)",
+  "homepage": "https://amagi.dev/react-vfx",
   "repository": {
     "url": "https://github.com/fand/react-vfx"
   },
-  "scripts": {
-    "build": "run-s clean build:cjs build:esm build:dual",
-    "build:cjs": "tsc -d",
-    "build:esm": "tsc -d -p tsconfig.esm.json",
-    "build:dual": "tsconfig-to-dual-package",
-    "clean": "rimraf lib",
-    "dev": "run-p watch:cjs watch:esm",
-    "watch:cjs": "tsc -d -w",
-    "watch:esm": "tsc -d -w -p tsconfig.esm.json",
-    "lint": "eslint src/**/*.ts src/**/*.tsx",
-    "lint-staged": "lint-staged"
+  "bugs": {
+    "url": "https://github.com/fand/react-vfx/issues"
   },
-  "types": "lib/esm/index.d.ts"
+  "keywords": [
+    "glsl",
+    "react",
+    "threejs",
+    "webgl"
+  ],
+  "license": "MIT"
 }

--- a/packages/react-vfx/package.json
+++ b/packages/react-vfx/package.json
@@ -29,6 +29,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.1",
     "rimraf": "^5.0.7",
+    "tsconfig-to-dual-package": "^1.2.0",
     "typescript": "^5.4.5"
   },
   "homepage": "https://amagi.dev/react-vfx",
@@ -45,10 +46,17 @@
       "prettier --write"
     ]
   },
-  "main": "./lib/cjs/index.js",
+  "type": "module",
+  "main": "./lib/esm/index.js",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.mjs"
+    "require": {
+      "types": "./lib/cjs/index.d.ts",
+      "default": "./lib/cjs/index.js"
+    },
+    "import": {
+      "types": "./lib/esm/index.d.ts",
+      "default": "./lib/esm/index.js"
+    }
   },
   "peerDependencies": {
     "react": ">= 16.12.0",
@@ -58,9 +66,10 @@
     "url": "https://github.com/fand/react-vfx"
   },
   "scripts": {
-    "build": "run-s clean build:cjs build:esm",
+    "build": "run-s clean build:cjs build:esm build:dual",
     "build:cjs": "tsc -d",
     "build:esm": "tsc -d -p tsconfig.esm.json",
+    "build:dual": "tsconfig-to-dual-package",
     "clean": "rimraf lib",
     "dev": "run-p watch:cjs watch:esm",
     "watch:cjs": "tsc -d -w",

--- a/packages/react-vfx/src/element.tsx
+++ b/packages/react-vfx/src/element.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useEffect, useRef, useContext } from "react";
-import { VFXContext } from "./context";
 import type { VFXProps } from "@vfx-js/core";
+import { VFXContext } from "./context.js";
 
 type VFXElementProps<T extends keyof JSX.IntrinsicElements> =
     JSX.IntrinsicElements[T] & VFXProps;

--- a/packages/react-vfx/src/hooks.ts
+++ b/packages/react-vfx/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { VFXContext } from "./context";
+import { VFXContext } from "./context.js";
 
 export type UseVFX = {
     /**

--- a/packages/react-vfx/src/image.tsx
+++ b/packages/react-vfx/src/image.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef, useContext, useEffect, useState } from "react";
-import { VFXContext } from "./context";
 import type { VFXProps } from "@vfx-js/core";
+import { VFXContext } from "./context.js";
 
 export type VFXImgProps = JSX.IntrinsicElements["img"] & VFXProps;
 

--- a/packages/react-vfx/src/index.mts
+++ b/packages/react-vfx/src/index.mts
@@ -1,1 +1,0 @@
-export * from "./react-vfx";

--- a/packages/react-vfx/src/index.ts
+++ b/packages/react-vfx/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./react-vfx";
+export * from "./react-vfx.js";

--- a/packages/react-vfx/src/provider.tsx
+++ b/packages/react-vfx/src/provider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState, useEffect } from "react";
-import { VFXContext } from "./context";
 import { VFX } from "@vfx-js/core";
+import { VFXContext } from "./context.js";
 
 export interface VFXProviderProps {
     children?: React.ReactNode;

--- a/packages/react-vfx/src/react-vfx.ts
+++ b/packages/react-vfx/src/react-vfx.ts
@@ -1,10 +1,10 @@
-export { VFXProvider } from "./provider";
-export { VFXImg } from "./image";
-export { VFXVideo } from "./video";
+export { VFXProvider } from "./provider.js";
+export { VFXImg } from "./image.js";
+export { VFXVideo } from "./video.js";
 
-import vElementFactory from "./element";
+import vElementFactory from "./element.js";
 export const VFXSpan = vElementFactory<"span">("span");
 export const VFXDiv = vElementFactory<"div">("div");
 export const VFXP = vElementFactory<"p">("p");
 
-export * from "./hooks";
+export * from "./hooks.js";

--- a/packages/react-vfx/src/video.tsx
+++ b/packages/react-vfx/src/video.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef, useContext, useState, useEffect } from "react";
-import { VFXContext } from "./context";
 import type { VFXProps } from "@vfx-js/core";
+import { VFXContext } from "./context.js";
 
 export type VFXVideoProps = JSX.IntrinsicElements["video"] & VFXProps;
 

--- a/packages/vfx-js/.prettierrc.mjs
+++ b/packages/vfx-js/.prettierrc.mjs
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
     tabWidth: 4,
 };

--- a/packages/vfx-js/package.json
+++ b/packages/vfx-js/package.json
@@ -14,6 +14,7 @@
     "README.md",
     "lib/"
   ],
+  "type": "module",
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/three": "^0.165.0",

--- a/packages/vfx-js/package.json
+++ b/packages/vfx-js/package.json
@@ -2,19 +2,42 @@
   "name": "@vfx-js/core",
   "description": "Easy WebGL effects for HTML elements",
   "version": "0.2.0",
-  "author": "Takayosi Amagi <fand.gmork@gmail.com> (https://amagi.dev/)",
-  "bugs": {
-    "url": "https://github.com/fand/react-vfx/issues"
-  },
-  "dependencies": {
-    "three": "^0.165.0"
-  },
   "files": [
     "package.json",
     "README.md",
     "lib/"
   ],
   "type": "module",
+  "main": "./lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "exports": {
+    "require": {
+      "types": "./lib/cjs/index.d.ts",
+      "default": "./lib/cjs/index.js"
+    },
+    "import": {
+      "types": "./lib/esm/index.d.ts",
+      "default": "./lib/esm/index.js"
+    }
+  },
+  "scripts": {
+    "build": "run-s clean build:cjs build:esm build:dual",
+    "build:cjs": "tsc -d",
+    "build:esm": "tsc -d -p tsconfig.esm.json",
+    "build:dual": "tsconfig-to-dual-package",
+    "clean": "rimraf lib",
+    "dev": "run-p watch:cjs watch:esm",
+    "watch:cjs": "tsc -d -w",
+    "watch:esm": "tsc -d -w -p tsconfig.esm.json",
+    "lint": "eslint src/**/*.ts",
+    "lint-staged": "lint-staged",
+    "test": "vitest --dir src --run",
+    "test:watch": "vitest --dir src",
+    "typedoc": "typedoc --out ../docs-vfx-js/docs"
+  },
+  "dependencies": {
+    "three": "^0.165.0"
+  },
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/three": "^0.165.0",
@@ -34,47 +57,24 @@
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   },
-  "homepage": "https://amagi.dev/vfx-js",
-  "keywords": [
-    "glsl",
-    "threejs",
-    "webgl"
-  ],
-  "license": "MIT",
   "lint-staged": {
     "src/*.ts": [
       "eslint --fix",
       "prettier --write"
     ]
   },
-  "main": "./lib/esm/index.js",
-  "exports": {
-    "require": {
-      "types": "./lib/cjs/index.d.ts",
-      "default": "./lib/cjs/index.js"
-    },
-    "import": {
-      "types": "./lib/esm/index.d.ts",
-      "default": "./lib/esm/index.js"
-    }
-  },
+  "author": "Takayosi Amagi <fand.gmork@gmail.com> (https://amagi.dev/)",
+  "homepage": "https://amagi.dev/vfx-js",
   "repository": {
     "url": "https://github.com/fand/react-vfx"
   },
-  "scripts": {
-    "build": "run-s clean build:cjs build:esm build:dual",
-    "build:cjs": "tsc -d",
-    "build:esm": "tsc -d -p tsconfig.esm.json",
-    "build:dual": "tsconfig-to-dual-package",
-    "clean": "rimraf lib",
-    "dev": "run-p watch:cjs watch:esm",
-    "watch:cjs": "tsc -d -w",
-    "watch:esm": "tsc -d -w -p tsconfig.esm.json",
-    "lint": "eslint src/**/*.ts",
-    "lint-staged": "lint-staged",
-    "test": "vitest --dir src --run",
-    "test:watch": "vitest --dir src",
-    "typedoc": "typedoc --out ../docs-vfx-js/docs"
+  "bugs": {
+    "url": "https://github.com/fand/react-vfx/issues"
   },
-  "types": "lib/esm/index.d.ts"
+  "keywords": [
+    "glsl",
+    "threejs",
+    "webgl"
+  ],
+  "license": "MIT"
 }

--- a/packages/vfx-js/package.json
+++ b/packages/vfx-js/package.json
@@ -28,6 +28,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.1",
     "rimraf": "^5.0.7",
+    "tsconfig-to-dual-package": "^1.2.0",
     "typedoc": "^0.26.2",
     "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "^5.4.5",
@@ -46,18 +47,25 @@
       "prettier --write"
     ]
   },
-  "main": "./lib/cjs/index.js",
+  "main": "./lib/esm/index.js",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.mjs"
+    "require": {
+      "types": "./lib/cjs/index.d.ts",
+      "default": "./lib/cjs/index.js"
+    },
+    "import": {
+      "types": "./lib/esm/index.d.ts",
+      "default": "./lib/esm/index.js"
+    }
   },
   "repository": {
     "url": "https://github.com/fand/react-vfx"
   },
   "scripts": {
-    "build": "run-s clean build:cjs build:esm",
+    "build": "run-s clean build:cjs build:esm build:dual",
     "build:cjs": "tsc -d",
     "build:esm": "tsc -d -p tsconfig.esm.json",
+    "build:dual": "tsconfig-to-dual-package",
     "clean": "rimraf lib",
     "dev": "run-p watch:cjs watch:esm",
     "watch:cjs": "tsc -d -w",

--- a/packages/vfx-js/src/gif.ts
+++ b/packages/vfx-js/src/gif.ts
@@ -1,4 +1,4 @@
-import GIF from "./gifuct-js";
+import GIF from "./gifuct-js/index.js";
 
 interface GIFFrame {
     patch: Uint8ClampedArray;

--- a/packages/vfx-js/src/gifuct-js/dataparser.js
+++ b/packages/vfx-js/src/gifuct-js/dataparser.js
@@ -1,6 +1,6 @@
 // Primary data parsing object used to parse byte arrays
 
-import ByteStream from "./bytestream";
+import ByteStream from "./bytestream.js";
 
 function DataParser(data) {
     this.stream = new ByteStream(data);
@@ -73,7 +73,7 @@ DataParser.prototype.parseBits = function (details) {
         if (item.length) {
             // convert the bit set to value
             out[key] = bitsToNum(
-                bits.slice(item.index, item.index + item.length)
+                bits.slice(item.index, item.index + item.length),
             );
         } else {
             out[key] = bits[item.index];

--- a/packages/vfx-js/src/gifuct-js/gif.js
+++ b/packages/vfx-js/src/gifuct-js/gif.js
@@ -1,7 +1,7 @@
 // object used to represent array buffer data for a gif file
 
-import DataParser from "./dataparser";
-import gifSchema from "./schema";
+import DataParser from "./dataparser.js";
+import gifSchema from "./schema.js";
 
 function GIF(arrayBuffer) {
     // convert to byte array
@@ -39,7 +39,7 @@ GIF.prototype.decompressFrame = function (index, buildPatch) {
         var pixels = lzw(
             frame.image.data.minCodeSize,
             frame.image.data.blocks,
-            totalPixels
+            totalPixels,
         );
 
         // deal with interlacing if necessary
@@ -215,11 +215,11 @@ GIF.prototype.decompressFrame = function (index, buildPatch) {
         var cpRow = function (toRow, fromRow) {
             var fromPixels = pixels.slice(
                 fromRow * width,
-                (fromRow + 1) * width
+                (fromRow + 1) * width,
             );
             newPixels.splice.apply(
                 newPixels,
-                [toRow * width, width].concat(fromPixels)
+                [toRow * width, width].concat(fromPixels),
             );
         };
 

--- a/packages/vfx-js/src/gifuct-js/index.js
+++ b/packages/vfx-js/src/gifuct-js/index.js
@@ -1,2 +1,2 @@
-import GIF from "./gif";
+import GIF from "./gif.js";
 export default GIF;

--- a/packages/vfx-js/src/gifuct-js/schema.js
+++ b/packages/vfx-js/src/gifuct-js/schema.js
@@ -2,7 +2,7 @@
 // For js object convenience (re-use), the schema objects are approximately reverse ordered
 
 // common parsers available
-import Parsers from "./parsers";
+import Parsers from "./parsers.js";
 
 // a set of 0x00 terminated subblocks
 var subBlocks = {

--- a/packages/vfx-js/src/index.mts
+++ b/packages/vfx-js/src/index.mts
@@ -1,4 +1,4 @@
-export * from "./vfx";
-export * from "./constants";
+export * from "./vfx.js";
+export * from "./constants.js";
 
-export type * from "./types";
+export type * from "./types.js";

--- a/packages/vfx-js/src/index.mts
+++ b/packages/vfx-js/src/index.mts
@@ -1,4 +1,0 @@
-export * from "./vfx.js";
-export * from "./constants.js";
-
-export type * from "./types.js";

--- a/packages/vfx-js/src/index.ts
+++ b/packages/vfx-js/src/index.ts
@@ -3,7 +3,7 @@
  * @module VFX-JS
  */
 
-export * from "./vfx";
-export * from "./constants";
+export * from "./vfx.js";
+export * from "./constants.js";
 
-export type { VFXOpts, VFXProps } from "./types";
+export type { VFXOpts, VFXProps } from "./types.js";

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -1,5 +1,5 @@
 import THREE from "three";
-import { ShaderPreset } from "./constants";
+import { ShaderPreset } from "./constants.js";
 
 /**
  * Options to initialize `VFX` class.

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
-import dom2canvas from "./dom-to-canvas";
-import { shaders, DEFAULT_VERTEX_SHADER } from "./constants";
-import GIFData from "./gif";
+import dom2canvas from "./dom-to-canvas.js";
+import { shaders, DEFAULT_VERTEX_SHADER } from "./constants.js";
+import GIFData from "./gif.js";
 import {
     VFXProps,
     VFXElement,

--- a/packages/vfx-js/src/vfx.ts
+++ b/packages/vfx-js/src/vfx.ts
@@ -1,5 +1,5 @@
-import { VFXPlayer } from "./vfx-player";
-import { VFXOpts, VFXProps } from "./types";
+import { VFXPlayer } from "./vfx-player.js";
+import { VFXOpts, VFXProps } from "./types.js";
 
 const canvasStyle = {
     position: "fixed",


### PR DESCRIPTION
This PR solves the issue VFX-JS files can't be loaded in native Node.js environments, such as SSR.
ref. https://github.com/fand/react-vfx/issues/72

## Changes
- Added `.js` extensions to imports
- Change default package type to ESM (`"type": "module"`)
- Fix dual packaging settings
- Tidy up `package.json`