### PR TITLE
fix: VFXImg / VFXVideo not working when initialized after the img / video is loaded

### DIFF
--- a/packages/react-vfx/src/image.tsx
+++ b/packages/react-vfx/src/image.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useRef, useContext, useEffect, useState } from "react";
+import { useRef, useContext, useEffect } from "react";
 import type { VFXProps } from "@vfx-js/core";
 import { VFXContext } from "./context.js";
 
@@ -10,11 +10,10 @@ export const VFXImg: React.FC<VFXImgProps> = (props) => {
 
     const vfx = useContext(VFXContext);
     const ref = useRef<HTMLImageElement>(null);
-    const [isLoaded, setIsLoaded] = useState(false);
 
     // Create scene
     useEffect(() => {
-        if (!vfx || !ref.current || !isLoaded) {
+        if (!vfx || !ref.current) {
             return;
         }
         const element = ref.current;
@@ -30,7 +29,7 @@ export const VFXImg: React.FC<VFXImgProps> = (props) => {
         return () => {
             vfx.remove(element);
         };
-    }, [vfx, shader, release, uniforms, overflow, wrap, isLoaded]);
+    }, [vfx, shader, release, uniforms, overflow, wrap]);
 
-    return <img ref={ref} {...rawProps} onLoad={() => setIsLoaded(true)} />;
+    return <img ref={ref} {...rawProps} />;
 };

--- a/packages/react-vfx/src/video.tsx
+++ b/packages/react-vfx/src/video.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useRef, useContext, useState, useEffect } from "react";
+import { useRef, useContext, useEffect } from "react";
 import type { VFXProps } from "@vfx-js/core";
 import { VFXContext } from "./context.js";
 
@@ -10,11 +10,10 @@ export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
 
     const vfx = useContext(VFXContext);
     const ref = useRef<HTMLVideoElement>(null);
-    const [isLoaded, setIsLoaded] = useState(false);
 
     // Create scene
     useEffect(() => {
-        if (!vfx || !ref.current || !isLoaded) {
+        if (!vfx || !ref.current) {
             return;
         }
         const element = ref.current;
@@ -30,9 +29,7 @@ export const VFXVideo: React.FC<VFXVideoProps> = (props) => {
         return () => {
             vfx.remove(element);
         };
-    }, [vfx, shader, release, uniforms, overflow, wrap, isLoaded]);
+    }, [vfx, shader, release, uniforms, overflow, wrap]);
 
-    return (
-        <video ref={ref} {...rawProps} onLoadedData={() => setIsLoaded(true)} />
-    );
+    return <video ref={ref} {...rawProps} />;
 };


### PR DESCRIPTION
We added `isLoading` guard to wait for img/video load in https://github.com/fand/react-vfx/pull/69 , however it's causing REACT-VFX not initializing correctly when the img/video is already loaded.
We improved the loading algorithm on VFX-JS side, so we can remove `isLoading` guard safely now.
