### PR TITLE
 fix: prevent main loop from running more than once

### DIFF
--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -32,7 +32,7 @@ export class VFXPlayer {
     #canvas: HTMLCanvasElement;
     #renderer: THREE.WebGLRenderer;
     #camera: THREE.Camera;
-    #isPlaying = false;
+    #playRequest: number | undefined = undefined;
     #pixelRatio = 2;
     #elements: VFXElement[] = [];
 
@@ -300,13 +300,21 @@ export class VFXPlayer {
         return Promise.resolve();
     }
 
+    isPlaying(): boolean {
+        return this.#playRequest !== undefined;
+    }
+
     play(): void {
-        this.#isPlaying = true;
-        this.#playLoop();
+        if (!this.isPlaying()) {
+            this.#playRequest = requestAnimationFrame(this.#playLoop);
+        }
     }
 
     stop(): void {
-        this.#isPlaying = false;
+        if (this.#playRequest !== undefined) {
+            cancelAnimationFrame(this.#playRequest);
+            this.#playRequest = undefined;
+        }
     }
 
     #lastNow = 0;
@@ -405,8 +413,8 @@ export class VFXPlayer {
             }
         }
 
-        if (this.#isPlaying) {
-            requestAnimationFrame(this.#playLoop);
+        if (this.isPlaying()) {
+            this.#playRequest = requestAnimationFrame(this.#playLoop);
         }
     };
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -317,15 +317,8 @@ export class VFXPlayer {
         }
     }
 
-    #lastNow = 0;
-
     #playLoop = (): void => {
         const now = Date.now() / 1000;
-
-        // TMP: log estimated FPS
-        const fps = 1 / (now - this.#lastNow);
-        console.log(">> FPS:", fps.toFixed(5));
-        this.#lastNow = now;
 
         this.#renderer.clear();
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -309,8 +309,15 @@ export class VFXPlayer {
         this.#isPlaying = false;
     }
 
+    #lastNow = 0;
+
     #playLoop = (): void => {
         const now = Date.now() / 1000;
+
+        // TMP: log estimated FPS
+        const fps = 1 / (now - this.#lastNow);
+        console.log(">> FPS:", fps.toFixed(5));
+        this.#lastNow = now;
 
         this.#renderer.clear();
 


### PR DESCRIPTION
Previously, if `VFX.play()` is called more than once, the main loop runs more than once in a frame.
This PR fixes this by managing the running state using the frame ID returned from `requestAnimationFrame`.

