### PR TITLE
feat: add VFXProps.overlay

### DIFF
--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -86,6 +86,20 @@ export type VFXProps = {
     uniforms?: VFXUniforms;
 
     /**
+     * The opacity for the original HTML element.
+     *
+     * By default, VFX-JS hides the original element by setting its opacity to 0.
+     * However, in some cases you might want not to hide the original element.
+     * `overlay` allows you to specify the opacity to be set explicitly.
+     *
+     * If you pass `true`, VFX-JS will preserve the original element's opacity.
+     *
+     * You can also specify the opacity by passing a number.
+     * For example, `overlay: 0.5` will set the opacity of the orignal element to 0.5.
+     */
+    overlay?: true | number;
+
+    /**
      * Allow shader outputs to oveflow the original element area.
      * If true, REACT-VFX will render the shader in fullscreen.
      * If number is specified, REACT-VFX adds paddings with the given value.

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -217,8 +217,14 @@ export class VFXPlayer {
         texture.needsUpdate = true;
 
         // Hide original element
-        const opacity = type === "video" ? "0.0001" : "0"; // don't hide video element completely to prevent jank frames
-        element.style.setProperty("opacity", opacity);
+        if (opts.overlay === true) {
+            /* Overlay mode. Do not hide the element */
+        } else if (typeof opts.overlay === "number") {
+            element.style.setProperty("opacity", opts.overlay.toString());
+        } else {
+            const opacity = type === "video" ? "0.0001" : "0"; // don't hide video element completely to prevent jank frames
+            element.style.setProperty("opacity", opacity.toString());
+        }
 
         const uniforms: { [name: string]: THREE.IUniform } = {
             src: { value: texture },


### PR DESCRIPTION
This PR adds new property: `VFXProps.overlay`.
It allows us to control the opacity of the original element.

By default, VFX-JS hides the original element by setting its opacity to 0.
However, in some cases you might want not to hide the original element.
`overlay` allows you to specify the opacity to be set explicitly.

This is useful when you want to show an effect on top of the original element.
This could also be used to avoid the scroll rag issue, if the shader is adding some decoration on the element, rather than replacing the element.
 

## Changes
- Add `VFXProps.overlay` 
- Set the opacity of the original element by `VFXProps.overlay`