### PR TITLE
feat: support HTMLCanvasElement for input

### DIFF
--- a/packages/docs-vfx-js/index.css
+++ b/packages/docs-vfx-js/index.css
@@ -207,7 +207,6 @@ a:visited {
     gap: 16px;
     overflow: hidden;
 }
-
 #div p {
     margin: 0;
 }
@@ -219,6 +218,11 @@ a:visited {
 }
 #div textarea {
     resize: vertical;
+}
+
+#canvas {
+    width: 100%;
+    aspect-ratio: 4 / 3;
 }
 
 /*================ AuthorSection ================*/

--- a/packages/docs-vfx-js/index.html
+++ b/packages/docs-vfx-js/index.html
@@ -256,6 +256,39 @@ mo.observe(textarea, { attributes: true });
                         </div>
                     </div>
                 </div>
+
+                <div class="row">
+                    <div class="col">
+                        <p>Canvas</p>
+                        <pre><code class="language-html">
+&lt;!--
+  VFX-JS also supports HTMLCanvasElement as the input.
+  You can draw 2D graphics and text in canvas,
+  then pass it to VFX-JS to add post effects.
+--&gt;
+&lt;canvas id="canvas"/&gt;
+                        </code></pre>
+
+                        <pre><code class="language-javascript">
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
+
+function drawCanvas() {
+    ...
+
+    vfx.update(canvas);
+    requestAnimationFrame(drawCanvas);
+}
+drawCanvas();
+
+vfx.add(canvas, { shader });
+                    </code></pre>
+                    </div>
+                    <div class="col">
+                        <p>Output:</p>
+                        <canvas id="canvas" />
+                    </div>
+                </div>
             </section>
 
             <div>

--- a/packages/docs-vfx-js/index.html
+++ b/packages/docs-vfx-js/index.html
@@ -276,7 +276,9 @@ const ctx = canvas.getContext("2d");
 function drawCanvas() {
     ...
 
+    // Update texture when the canvas has been updated
     vfx.update(canvas);
+
     requestAnimationFrame(drawCanvas);
 }
 drawCanvas();

--- a/packages/docs-vfx-js/src/main.ts
+++ b/packages/docs-vfx-js/src/main.ts
@@ -271,7 +271,24 @@ class App {
             isMouseOn = false;
         });
 
+        let isInside = false;
+        const io = new IntersectionObserver(
+            (changes) => {
+                for (const c of changes) {
+                    isInside = c.intersectionRatio > 0.1;
+                }
+            },
+            { threshold: [0, 1, 0.2, 0.8] },
+        );
+        io.observe(canvas);
+
         const drawMouseStalker = () => {
+            requestAnimationFrame(drawMouseStalker);
+
+            if (!isInside) {
+                return;
+            }
+
             if (!isMouseOn) {
                 const t = Date.now() / 1000 - startTime;
                 target = [
@@ -289,7 +306,7 @@ class App {
             ctx.fillRect(0, 0, width, height);
 
             ctx.fillStyle = "white";
-            ctx.font = "bold 120px sans-serif";
+            ctx.font = `bold ${width * 0.14}px sans-serif`;
             ctx.fillText("HOVER ME", width / 2, height / 2);
             ctx.textBaseline = "middle";
             ctx.textAlign = "center";
@@ -304,7 +321,6 @@ class App {
             }
 
             this.vfx.update(canvas);
-            requestAnimationFrame(drawMouseStalker);
         };
         drawMouseStalker();
 

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -165,7 +165,7 @@ export type VFXUniformValue =
 /**
  * @internal
  */
-export type VFXElementType = "img" | "video" | "text";
+export type VFXElementType = "img" | "video" | "text" | "canvas";
 
 /**
  * @internal

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -318,6 +318,13 @@ export class VFXPlayer {
         return Promise.resolve();
     }
 
+    updateCanvasElement(element: HTMLCanvasElement): void {
+        const e = this.#elements.find((e) => e.element === element);
+        if (e) {
+            e.uniforms["src"].value.needsUpdate = true;
+        }
+    }
+
     isPlaying(): boolean {
         return this.#playRequest !== undefined;
     }

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -202,6 +202,9 @@ export class VFXPlayer {
         } else if (element instanceof HTMLVideoElement) {
             texture = new THREE.VideoTexture(element);
             type = "video" as VFXElementType;
+        } else if (element instanceof HTMLCanvasElement) {
+            texture = new THREE.CanvasTexture(element);
+            type = "canvas" as VFXElementType;
         } else {
             const canvas = await dom2canvas(element, originalOpacity);
             texture = new THREE.CanvasTexture(canvas);

--- a/packages/vfx-js/src/vfx.ts
+++ b/packages/vfx-js/src/vfx.ts
@@ -44,6 +44,8 @@ export class VFX {
             this.#addImage(element, opts);
         } else if (element instanceof HTMLVideoElement) {
             this.#addVideo(element, opts);
+        } else if (element instanceof HTMLCanvasElement) {
+            this.#addCanvas(element, opts);
         } else {
             this.#addText(element, opts);
         }
@@ -117,6 +119,10 @@ export class VFX {
                 { once: true },
             );
         }
+    }
+
+    #addCanvas(element: HTMLCanvasElement, opts: VFXProps): void {
+        this.#player.addElement(element, opts);
     }
 
     #addText(element: HTMLElement, opts: VFXProps): void {

--- a/packages/vfx-js/src/vfx.ts
+++ b/packages/vfx-js/src/vfx.ts
@@ -66,8 +66,13 @@ export class VFX {
      *
      * This is useful to apply effects to eleents whose contents change dynamically (e.g. input, textare etc).
      */
-    update(element: HTMLElement): Promise<void> {
-        return this.#player.updateTextElement(element);
+    async update(element: HTMLElement): Promise<void> {
+        if (element instanceof HTMLCanvasElement) {
+            this.#player.updateCanvasElement(element);
+            return;
+        } else {
+            return this.#player.updateTextElement(element);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds support for HTMLCanvasElement as an input.
This allows us to draw anything on canvas elements (2D graphics, text, p5js etc), then pass them to VFX-JS.